### PR TITLE
Rename x icon to cross.

### DIFF
--- a/maki-icon-source/maki-icons.svg
+++ b/maki-icon-source/maki-icons.svg
@@ -1299,8 +1299,8 @@
          style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
-       id="x-18"
-       inkscape:label="x-18"
+       id="cross-18"
+       inkscape:label="cross-18"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90">
       <g
@@ -1327,8 +1327,8 @@
          style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
-       id="x-12"
-       inkscape:label="x-12"
+       id="cross-12"
+       inkscape:label="cross-12"
        inkscape:export-xdpi="90"
        inkscape:export-ydpi="90">
       <g
@@ -6714,8 +6714,8 @@
          y="1338.3623" />
     </g>
     <g
-       id="x-24"
-       inkscape:label="x-24">
+       id="cross-24"
+       inkscape:label="cross-24">
       <path
          inkscape:connector-curvature="0"
          id="path7139"


### PR DESCRIPTION
Renames the `x` icon to `cross` to match ID on http://mapbox.com/maki and to avoid naming conflict with the letter x.
