### PR TITLE
Add /core prefix.

### DIFF
--- a/_config.mb-pages.yml
+++ b/_config.mb-pages.yml
@@ -1,5 +1,5 @@
 url: https://www.mapbox.com
-api: https://www.mapbox.com
+api: https://www.mapbox.com/core
 tileApi: https://api.tiles.mapbox.com
 exclude:
   - README.markdown

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 url: https://122e4e-mapbox.global.ssl.fastly.net
-api: https://122e4e-mapbox.global.ssl.fastly.net
+api: https://122e4e-mapbox.global.ssl.fastly.net/core
 tileApi: https://api-maps-staging.tilestream.net
 exclude:
   - README.markdown


### PR DESCRIPTION
Core API proxy for www.mapbox.com is moving under `/core`.
