### PR TITLE
Add Bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,27 @@
+{
+  "name": "maki",
+  "author": "MapBox",
+  "main": "index.js",
+  "version": "0.4.6",
+  "homepage": "http://mapbox.com/maki",
+  "description": "Pixel-perfect icons for web cartography",
+  "keywords": [
+    "icons",
+    "map",
+    "svg",
+    "png"
+  ],
+  "license": "CC0",
+  "ignore": [
+    "**/.*",
+    "**/_*",
+    "www",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "promo-graphics",
+    "www",
+    "dev-render.sh"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "MapBox",
   "name": "maki",
   "description": "Pixel-perfect icons for web cartography",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "homepage": "http://mapbox.com/maki",
   "scripts": {
     "test": "tap test/*.js"


### PR DESCRIPTION
This PR adds Bower support!

To finish setting up Bower, someone will need to:
- [ ] create a new version tag (I bumped the version to v0.4.6 in this PR in `package.json` and `bower.json`)
- [ ] run `bower register maki git://github.com/mapbox/maki.git`

Thanks for building these beautiful map icons!