### PR TITLE
Set background rect opacity to 0 for all SVGs

### DIFF
--- a/src/airfield-12.svg
+++ b/src/airfield-12.svg
@@ -118,7 +118,7 @@
            sodipodi:nodetypes="sssccccccccccccccccccssss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22192-14-7-4"
          width="11.999998"
          height="12.000007"

--- a/src/airfield-18.svg
+++ b/src/airfield-18.svg
@@ -126,7 +126,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22190-58-4"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/airfield-24.svg
+++ b/src/airfield-24.svg
@@ -122,7 +122,7 @@
          height="24.000017"
          width="24"
          id="rect6156"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/airport-12.svg
+++ b/src/airport-12.svg
@@ -122,7 +122,7 @@
            sodipodi:nodetypes="cccccccccccccssscc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22079-3"
          width="11.999998"
          height="12.000007"

--- a/src/airport-18.svg
+++ b/src/airport-18.svg
@@ -129,7 +129,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22077-6"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/airport-24.svg
+++ b/src/airport-24.svg
@@ -129,7 +129,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22075-7"
          width="24"
          height="24.000017"

--- a/src/alcohol-shop-12.svg
+++ b/src/alcohol-shop-12.svg
@@ -112,7 +112,7 @@
          transform="translate(-120,1050.3622)"
          id="path8755" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22286-3-7"
          width="11.999998"
          height="12.000007"

--- a/src/alcohol-shop-18.svg
+++ b/src/alcohol-shop-18.svg
@@ -117,7 +117,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22284-6-5"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          id="path5792"
          d="m 582.5,1076.3622 -0.5,0.5 0,3 -2,2.5 0,8 6,0 0,-8 -2,-2.5 0,-3 -0.5,-0.5 -1,0 z m 4.5,6 0,3 c 0,0 0,1 1,1 l 1,0 0,3 -1.5,0.5 -0.5,0.5 5,0 -0.5,-0.5 -1.5,-0.5 0,-3 1,0 c 1,0 1,-1 1,-1 l 0,-3 -5,0 z"

--- a/src/alcohol-shop-24.svg
+++ b/src/alcohol-shop-24.svg
@@ -121,7 +121,7 @@
          id="path8739"
          sodipodi:nodetypes="cccccccccccccccccccccccccccccc" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22282-1-3"
          width="24"
          height="24.000017"

--- a/src/america-football-12.svg
+++ b/src/america-football-12.svg
@@ -117,7 +117,7 @@
            sodipodi:nodetypes="scscsccccccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22298-6"
          width="11.999998"
          height="12.000007"

--- a/src/america-football-18.svg
+++ b/src/america-football-18.svg
@@ -125,7 +125,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22296-3"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/america-football-24.svg
+++ b/src/america-football-24.svg
@@ -128,7 +128,7 @@
            id="path14961" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22294-1"
          width="24"
          height="24.000017"

--- a/src/bank-12.svg
+++ b/src/bank-12.svg
@@ -127,7 +127,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22425"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/bank-18.svg
+++ b/src/bank-18.svg
@@ -122,7 +122,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22423"
          width="18.000017"
          height="18.000031"

--- a/src/bank-24.svg
+++ b/src/bank-24.svg
@@ -138,7 +138,7 @@
          height="24.000017"
          width="24"
          id="rect22421"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/bar-12.svg
+++ b/src/bar-12.svg
@@ -127,7 +127,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22419"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/bar-18.svg
+++ b/src/bar-18.svg
@@ -121,7 +121,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22417"
          width="18.000017"
          height="18.000031"

--- a/src/bar-24.svg
+++ b/src/bar-24.svg
@@ -135,7 +135,7 @@
          height="24.000017"
          width="24"
          id="rect22415"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/baseball-12.svg
+++ b/src/baseball-12.svg
@@ -122,7 +122,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22589"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/baseball-18.svg
+++ b/src/baseball-18.svg
@@ -120,7 +120,7 @@
            sodipodi:nodetypes="cscccccccccccccsssss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22587"
          width="18.000017"
          height="18.000031"

--- a/src/baseball-24.svg
+++ b/src/baseball-24.svg
@@ -126,7 +126,7 @@
          height="24.000017"
          width="24"
          id="rect22585"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/basketball-12.svg
+++ b/src/basketball-12.svg
@@ -121,7 +121,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22583"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/basketball-18.svg
+++ b/src/basketball-18.svg
@@ -119,7 +119,7 @@
            id="rect5769-7-5" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22581"
          width="18.000017"
          height="18.000031"

--- a/src/basketball-24.svg
+++ b/src/basketball-24.svg
@@ -125,7 +125,7 @@
          height="24.000017"
          width="24"
          id="rect22579"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/building-18.svg
+++ b/src/building-18.svg
@@ -123,7 +123,7 @@
          height="18.000031"
          width="18.000017"
          id="rect5873"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/building-24.svg
+++ b/src/building-24.svg
@@ -125,7 +125,7 @@
          height="24.000034"
          width="24.000017"
          id="rect5877"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          d="m 641,1077.3622 -7.5,6.5 c -0.3561,0.3086 -0.5,0.5 -0.5,0.75 0,0.4959 0.5,0.75 1,0.75 l 1,0 0,8 c 0,0.554 0.446,1 1,1 l 6.5,0 6.5,0 c 0.554,0 1,-0.446 1,-1 l 0,-8 1,0 c 0.5,0 1,-0.2541 1,-0.75 0,-0.25 -0.13799,-0.4483 -0.5,-0.75 l -7.5,-6.5 z"

--- a/src/bus-12.svg
+++ b/src/bus-12.svg
@@ -122,7 +122,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22174"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/bus-18.svg
+++ b/src/bus-18.svg
@@ -120,7 +120,7 @@
            id="path8522-6-8-58" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22172"
          width="18.000017"
          height="18.000031"

--- a/src/cafe-12.svg
+++ b/src/cafe-12.svg
@@ -121,7 +121,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22292-9"
          width="11.999998"
          height="12.000007"

--- a/src/cafe-18.svg
+++ b/src/cafe-18.svg
@@ -126,7 +126,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22290-8"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/cafe-24.svg
+++ b/src/cafe-24.svg
@@ -129,7 +129,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22288-0"
          width="24"
          height="24.000017"

--- a/src/campsite-12.svg
+++ b/src/campsite-12.svg
@@ -118,7 +118,7 @@
            sodipodi:nodetypes="cccsssccsssccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22292"
          width="11.999998"
          height="12.000007"

--- a/src/campsite-18.svg
+++ b/src/campsite-18.svg
@@ -126,7 +126,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22290"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/campsite-24.svg
+++ b/src/campsite-24.svg
@@ -129,7 +129,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22288"
          width="24"
          height="24.000017"

--- a/src/cemetery-12.svg
+++ b/src/cemetery-12.svg
@@ -117,7 +117,7 @@
            sodipodi:nodetypes="sscsccscss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22139"
          width="11.999998"
          height="12.000007"

--- a/src/cemetery-18.svg
+++ b/src/cemetery-18.svg
@@ -125,7 +125,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22137"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/cemetery-24.svg
+++ b/src/cemetery-24.svg
@@ -121,7 +121,7 @@
            sodipodi:nodetypes="ssccsccscss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22135"
          width="24"
          height="24.000017"

--- a/src/cinema-12.svg
+++ b/src/cinema-12.svg
@@ -119,7 +119,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22292-1"
          width="11.999998"
          height="12.000007"

--- a/src/cinema-18.svg
+++ b/src/cinema-18.svg
@@ -126,7 +126,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22290-1"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/cinema-24.svg
+++ b/src/cinema-24.svg
@@ -129,7 +129,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22288-7"
          width="24"
          height="24.000017"

--- a/src/circle-12.svg
+++ b/src/circle-12.svg
@@ -126,7 +126,7 @@
            sodipodi:type="arc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect21977"
          width="11.999998"
          height="12.000007"

--- a/src/circle-18.svg
+++ b/src/circle-18.svg
@@ -133,7 +133,7 @@
          height="18.000031"
          width="18.000017"
          id="rect21975"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/circle-24.svg
+++ b/src/circle-24.svg
@@ -136,7 +136,7 @@
            transform="matrix(1.0303132,0,0,1.0303132,-61.121337,1003.2409)" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect21973"
          width="24"
          height="24.000017"

--- a/src/circle-stroked-12.svg
+++ b/src/circle-stroked-12.svg
@@ -107,7 +107,7 @@
          height="12.000007"
          width="11.999998"
          id="rect21971"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <g
          transform="translate(0,-1)"
          id="g21872">

--- a/src/circle-stroked-18.svg
+++ b/src/circle-stroked-18.svg
@@ -101,7 +101,7 @@
        inkscape:export-xdpi="89.996864"
        inkscape:export-ydpi="89.996864">
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect21969"
          width="18.000017"
          height="18.000031"

--- a/src/city-12.svg
+++ b/src/city-12.svg
@@ -109,7 +109,7 @@
          id="path9461"
          inkscape:connector-curvature="0" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect5991-0"
          width="12"
          height="12.000009"

--- a/src/city-18.svg
+++ b/src/city-18.svg
@@ -119,7 +119,7 @@
          height="18.000013"
          width="18"
          id="rect5989-6"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/city-24.svg
+++ b/src/city-24.svg
@@ -117,7 +117,7 @@
          id="path9456"
          inkscape:connector-curvature="0" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect7325-2-7"
          width="24"
          height="24.000017"

--- a/src/college-12.svg
+++ b/src/college-12.svg
@@ -122,7 +122,7 @@
            sodipodi:nodetypes="ccccccccccccsccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22292-2"
          width="11.999998"
          height="12.000007"

--- a/src/college-18.svg
+++ b/src/college-18.svg
@@ -126,7 +126,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22290-3"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/college-24.svg
+++ b/src/college-24.svg
@@ -127,7 +127,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22288-9"
          width="24"
          height="24.000017"

--- a/src/commercial-18.svg
+++ b/src/commercial-18.svg
@@ -118,7 +118,7 @@
          transform="translate(-120,1050.3622)"
          id="path5406" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect13488-3-7-0"
          width="18.000017"
          height="18.000031"

--- a/src/commercial-24.svg
+++ b/src/commercial-24.svg
@@ -127,7 +127,7 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ssccccccssscccccccccccccccccccccccccccccccccccccccc" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect13515-8-6-0"
          width="24.000017"
          height="24.000034"

--- a/src/cricket-12.svg
+++ b/src/cricket-12.svg
@@ -114,7 +114,7 @@
          style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          sodipodi:nodetypes="csccccccccccsssss" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22607"
          width="11.999998"
          height="12.000007"

--- a/src/cricket-18.svg
+++ b/src/cricket-18.svg
@@ -124,7 +124,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22605"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/cricket-24.svg
+++ b/src/cricket-24.svg
@@ -121,7 +121,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22603"
          width="24"
          height="24.000017"

--- a/src/cross-12.svg
+++ b/src/cross-12.svg
@@ -115,7 +115,7 @@
            style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22073"
          width="11.999998"
          height="12.000007"

--- a/src/cross-18.svg
+++ b/src/cross-18.svg
@@ -125,7 +125,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22071"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/cross-24.svg
+++ b/src/cross-24.svg
@@ -112,7 +112,7 @@
          style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;opacity:0.3;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
          sodipodi:nodetypes="ccccccccccccccccccccc" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22069"
          width="24"
          height="24.000017"

--- a/src/dam-12.svg
+++ b/src/dam-12.svg
@@ -122,7 +122,7 @@
            sodipodi:nodetypes="ccccccccccccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect7329"
          width="11.999998"
          height="12.000007"

--- a/src/dam-18.svg
+++ b/src/dam-18.svg
@@ -127,7 +127,7 @@
          height="18.000031"
          width="18.000017"
          id="rect7327"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/dam-24.svg
+++ b/src/dam-24.svg
@@ -130,7 +130,7 @@
            sodipodi:nodetypes="scccccccssscccccscccccscccsscccccscccccscccs" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect7325"
          width="24"
          height="24.000017"

--- a/src/danger-12.svg
+++ b/src/danger-12.svg
@@ -118,7 +118,7 @@
          d="m 599.5,1051.3622 -1.5,1.5 c 0,0 0,1.3333 0,2 l 1,1 c 0,0.1667 0,0.5 0,0.5 l 1.5,1 1.5,-1 0,-0.5 1,-1 0,-2 -1.5,-1.5 z m -0.5,2 1,0 0,0.5 -1,0 z m 2,0 1,0 0,0.5 -1,0 z m -5,3 0,1 0.56039,0.2802 2.43961,1.2198 -3,1.5 0,1 0.5,0 5.5,-2.5 3,-1.5 0,-1 -0.5,0 -3,1.5 -0.5,0.5 -1,0 -0.5,-0.5 -3,-1.5 z m 7,3 -1.5,0.5 3,1.5 0.5,0 0,-1 z"
          style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22286-3-7-3"
          width="11.999998"
          height="12.000007"

--- a/src/danger-18.svg
+++ b/src/danger-18.svg
@@ -123,7 +123,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22284-6-5-5"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/danger-24.svg
+++ b/src/danger-24.svg
@@ -129,7 +129,7 @@
          height="24.000017"
          width="24"
          id="rect5537"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/embassy-12.svg
+++ b/src/embassy-12.svg
@@ -115,7 +115,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22536"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          sodipodi:nodetypes="ccccccccccc"
          style="color:#000000;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"

--- a/src/embassy-18.svg
+++ b/src/embassy-18.svg
@@ -109,7 +109,7 @@
          style="opacity:0.3;color:#000000;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          sodipodi:nodetypes="ccccccccccc" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22534"
          width="18.000017"
          height="18.000031"

--- a/src/embassy-24.svg
+++ b/src/embassy-24.svg
@@ -128,7 +128,7 @@
          height="24.000017"
          width="24"
          id="rect22532"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/farm-12.svg
+++ b/src/farm-12.svg
@@ -115,7 +115,7 @@
          height="12.000009"
          width="12"
          id="rect5991-0-4-1-1"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          sodipodi:nodetypes="ccccccccccccccccccccccc"
          inkscape:connector-curvature="0"

--- a/src/farm-18.svg
+++ b/src/farm-18.svg
@@ -106,7 +106,7 @@
          d="m 667,1344.3622 0,8 4,0 0,-8 -1,-2 -2,0 z m -9.5,0 -2.5,3 1,0 0,5 9,0 0,-5 1,0 -2,-3 z"
          style="opacity:0.3;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect5989-6-0-6-5"
          width="18"
          height="18.000013"

--- a/src/farm-24.svg
+++ b/src/farm-24.svg
@@ -116,7 +116,7 @@
          height="24.000017"
          width="24"
          id="rect7325-2-7-0-6-5"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <g
          id="g6587">
         <path

--- a/src/fast-food-12.svg
+++ b/src/fast-food-12.svg
@@ -126,7 +126,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22304-2"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/fast-food-18.svg
+++ b/src/fast-food-18.svg
@@ -120,7 +120,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22302-4"
          width="18.000017"
          height="18.000031"

--- a/src/fast-food-24.svg
+++ b/src/fast-food-24.svg
@@ -134,7 +134,7 @@
          height="24.000017"
          width="24"
          id="rect22300-6"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/fire-station-12.svg
+++ b/src/fire-station-12.svg
@@ -122,7 +122,7 @@
            sodipodi:nodetypes="cccsssccccsssc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22292-6"
          width="11.999998"
          height="12.000007"

--- a/src/fire-station-18.svg
+++ b/src/fire-station-18.svg
@@ -125,7 +125,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22290-37"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/fire-station-24.svg
+++ b/src/fire-station-24.svg
@@ -125,7 +125,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22288-1"
          width="24"
          height="24.000017"

--- a/src/fuel-12.svg
+++ b/src/fuel-12.svg
@@ -115,7 +115,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22180"
          width="11.999998"
          height="12.000007"

--- a/src/fuel-18.svg
+++ b/src/fuel-18.svg
@@ -117,7 +117,7 @@
          id="rect7223-2-4-9-4-2-3"
          inkscape:connector-curvature="0" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22178-6-7"
          width="18.000017"
          height="18.000031"

--- a/src/fuel-24.svg
+++ b/src/fuel-24.svg
@@ -127,7 +127,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22176"
          width="24"
          height="24.000017"

--- a/src/garden-12.svg
+++ b/src/garden-12.svg
@@ -116,7 +116,7 @@
            id="path6080-4-3" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22286"
          width="11.999998"
          height="12.000007"

--- a/src/garden-18.svg
+++ b/src/garden-18.svg
@@ -133,7 +133,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22284"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/garden-24.svg
+++ b/src/garden-24.svg
@@ -122,7 +122,7 @@
          d="m 170.3,1198.3622 c -0.253,0 -0.3,0.5596 -0.3,1 l 0,2 c 0,2.0312 2,3.0625 4,3 l 0,8 c -1,-2 -4,-5 -7,-4 0,0 2.5,6 7.5,6 5,0 7.5,-6 7.5,-6 -3,-1 -6,2 -7,4 l 0,-8 c 2,0.062 4,-0.9688 4,-3 l 0,-2 c 0,-0.4404 -0.0468,-1 -0.3,-1 -0.19292,0 -0.42562,0.2256 -0.7,0.5 l -1.5,1.5 -1.5,-1.6875 c -0.15657,-0.1761 -0.24696,-0.3125 -0.5,-0.3125 -0.25305,0 -0.34343,0.1364 -0.5,0.3125 l -1.5,1.6875 -1.5,-1.5 c -0.27438,-0.2744 -0.50708,-0.5 -0.7,-0.5 z"
          style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22282"
          width="24"
          height="24.000017"

--- a/src/golf-12.svg
+++ b/src/golf-12.svg
@@ -122,7 +122,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22595"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/golf-18.svg
+++ b/src/golf-18.svg
@@ -120,7 +120,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22593"
          width="18.000017"
          height="18.000031"

--- a/src/golf-24.svg
+++ b/src/golf-24.svg
@@ -126,7 +126,7 @@
          height="24.000017"
          width="24"
          id="rect22591"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/grocery-12.svg
+++ b/src/grocery-12.svg
@@ -127,7 +127,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22431"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/grocery-18.svg
+++ b/src/grocery-18.svg
@@ -122,7 +122,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22429"
          width="18.000017"
          height="18.000031"

--- a/src/grocery-24.svg
+++ b/src/grocery-24.svg
@@ -135,7 +135,7 @@
          height="24.000017"
          width="24"
          id="rect22427"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/heliport-12.svg
+++ b/src/heliport-12.svg
@@ -118,7 +118,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22085-9"
          width="11.999998"
          height="12.000007"

--- a/src/heliport-18.svg
+++ b/src/heliport-18.svg
@@ -125,7 +125,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22083-9"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/heliport-24.svg
+++ b/src/heliport-24.svg
@@ -122,7 +122,7 @@
            sodipodi:nodetypes="sssscsscccssscccccsssccccccssscsssssss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22081-2"
          width="24"
          height="24.000017"

--- a/src/hospital-12.svg
+++ b/src/hospital-12.svg
@@ -132,7 +132,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22304"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/hospital-18.svg
+++ b/src/hospital-18.svg
@@ -123,7 +123,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22302"
          width="18.000017"
          height="18.000031"

--- a/src/hospital-24.svg
+++ b/src/hospital-24.svg
@@ -138,7 +138,7 @@
          height="24.000017"
          width="24"
          id="rect22300"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/industrial-18.svg
+++ b/src/industrial-18.svg
@@ -123,7 +123,7 @@
          height="18.000031"
          width="18.000017"
          id="rect13488-3-7"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/industrial-24.svg
+++ b/src/industrial-24.svg
@@ -131,7 +131,7 @@
          height="24.000034"
          width="24.000017"
          id="rect13515-8-6"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/land-use-12.svg
+++ b/src/land-use-12.svg
@@ -125,7 +125,7 @@
          height="12.000009"
          width="12"
          id="rect5991"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/land-use-18.svg
+++ b/src/land-use-18.svg
@@ -116,7 +116,7 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect5989"
          width="18"
          height="18.000013"

--- a/src/land-use-24.svg
+++ b/src/land-use-24.svg
@@ -129,7 +129,7 @@
          height="24.000017"
          width="24"
          id="rect7325-2"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/library-12.svg
+++ b/src/library-12.svg
@@ -122,7 +122,7 @@
            sodipodi:nodetypes="ccccsccscccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22298"
          width="11.999998"
          height="12.000007"

--- a/src/library-18.svg
+++ b/src/library-18.svg
@@ -126,7 +126,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22296"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/library-24.svg
+++ b/src/library-24.svg
@@ -126,7 +126,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22294"
          width="24"
          height="24.000017"

--- a/src/lodging-12.svg
+++ b/src/lodging-12.svg
@@ -122,7 +122,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22198"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/lodging-18.svg
+++ b/src/lodging-18.svg
@@ -120,7 +120,7 @@
            sodipodi:nodetypes="ssssscsccccsscscsssccssssss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22196"
          width="18.000017"
          height="18.000031"

--- a/src/lodging-24.svg
+++ b/src/lodging-24.svg
@@ -132,7 +132,7 @@
          height="24.000017"
          width="24"
          id="rect22194"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/logging-12.svg
+++ b/src/logging-12.svg
@@ -127,7 +127,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22292-1-0"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/logging-18.svg
+++ b/src/logging-18.svg
@@ -124,7 +124,7 @@
            sodipodi:nodetypes="ccccccccccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22290-1-7"
          width="18.000017"
          height="18.000031"

--- a/src/logging-24.svg
+++ b/src/logging-24.svg
@@ -137,7 +137,7 @@
          height="24.000017"
          width="24"
          id="rect22288-7-6"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/london-underground-12.svg
+++ b/src/london-underground-12.svg
@@ -112,7 +112,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22192-14-7"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          id="path8744"
          d="m 132.5,1270.3622 c -1.76528,0 -3.22866,1.301 -3.46875,3 l -1.03125,0 0,1 1.03125,0 c 0.24009,1.699 1.70347,3 3.46875,3 1.76528,0 3.22866,-1.301 3.46875,-3 l 1.03125,0 0,-1 -1.03125,0 c -0.24009,-1.699 -1.70347,-3 -3.46875,-3 z m 0,1.5 c 0.93197,0 1.71554,0.6373 1.9375,1.5 l -3.875,0 c 0.22196,-0.8627 1.00553,-1.5 1.9375,-1.5 z m -1.9375,2.5 3.875,0 c -0.22196,0.8627 -1.00553,1.5 -1.9375,1.5 -0.93197,0 -1.71554,-0.6373 -1.9375,-1.5 z"

--- a/src/london-underground-18.svg
+++ b/src/london-underground-18.svg
@@ -117,7 +117,7 @@
          transform="translate(-120,1050.3622)"
          id="path12671" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22190-58"
          width="18.000017"
          height="18.000031"

--- a/src/london-underground-24.svg
+++ b/src/london-underground-24.svg
@@ -107,7 +107,7 @@
          height="24.000017"
          width="24"
          id="rect8831"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <g
          id="g8833"
          style="display:inline"

--- a/src/maki-icons.svg
+++ b/src/maki-icons.svg
@@ -609,7 +609,7 @@
          height="12.000007"
          width="11.999998"
          id="rect21971"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <g
          transform="translate(0,-1)"
          id="g21872">
@@ -756,7 +756,7 @@
            sodipodi:type="arc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect21977"
          width="11.999998"
          height="12.000007"
@@ -844,7 +844,7 @@
            sodipodi:nodetypes="sssssssssccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect21983"
          width="11.999998"
          height="12.000007"
@@ -947,7 +947,7 @@
          height="12.000007"
          width="11.999998"
          id="rect21989"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="triangle-stroked-24"
@@ -973,7 +973,7 @@
            style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22045"
          width="24"
          height="24.000017"
@@ -1004,7 +1004,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22047"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="triangle-stroked-12"
@@ -1026,7 +1026,7 @@
            transform="translate(-120,1050.3622)" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22049"
          width="11.999998"
          height="12.000007"
@@ -1057,7 +1057,7 @@
            sodipodi:nodetypes="cccsccsccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22051"
          width="24"
          height="24.000017"
@@ -1090,7 +1090,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22053"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="triangle-12"
@@ -1113,7 +1113,7 @@
            style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22055"
          width="11.999998"
          height="12.000007"
@@ -1156,7 +1156,7 @@
          height="24.000017"
          width="24"
          id="rect22057"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="star-18"
@@ -1180,7 +1180,7 @@
            id="path4749-2-8-0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22059"
          width="18.000017"
          height="18.000031"
@@ -1215,7 +1215,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22061"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="star-stroked-24"
@@ -1253,7 +1253,7 @@
          height="24.000017"
          width="24"
          id="rect22063"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="star-stroked-18"
@@ -1277,7 +1277,7 @@
            sodipodi:nodetypes="cccccccccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22065"
          width="18.000017"
          height="18.000031"
@@ -1310,7 +1310,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22067"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="cross-18"
@@ -1338,7 +1338,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22071"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="cross-12"
@@ -1359,7 +1359,7 @@
            style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22073"
          width="11.999998"
          height="12.000007"
@@ -1395,7 +1395,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22075"
          width="24"
          height="24.000017"
@@ -1428,7 +1428,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22077"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="marker-stroked-12"
@@ -1453,7 +1453,7 @@
            sodipodi:nodetypes="sscsssscss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22079"
          width="11.999998"
          height="12.000007"
@@ -1490,7 +1490,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22081"
          width="24"
          height="24.000017"
@@ -1516,7 +1516,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22083"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          sodipodi:nodetypes="sscss"
          inkscape:connector-curvature="0"
@@ -1546,7 +1546,7 @@
            sodipodi:nodetypes="sscccccccccccss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22075-4"
          width="24"
          height="24.000017"
@@ -1581,7 +1581,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22077-2"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="religious-christian-12"
@@ -1605,7 +1605,7 @@
            sodipodi:nodetypes="cscccccccccccssc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22079-8"
          width="11.999998"
          height="12.000007"
@@ -1632,7 +1632,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22081-5"
          width="24"
          height="24.000017"
@@ -1666,7 +1666,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22083-8"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="religious-muslim-12"
@@ -1690,7 +1690,7 @@
            sodipodi:nodetypes="csscsssccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22085-4"
          width="11.999998"
          height="12.000007"
@@ -1724,7 +1724,7 @@
          height="24.000017"
          width="24"
          id="rect22087"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="religious-jewish-18"
@@ -1746,7 +1746,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22089"
          width="18.000017"
          height="18.000031"
@@ -1780,7 +1780,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22091"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="cemetery-24"
@@ -1803,7 +1803,7 @@
            sodipodi:nodetypes="ssccsccscss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22135"
          width="24"
          height="24.000017"
@@ -1836,7 +1836,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22137"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="cemetery-12"
@@ -1859,7 +1859,7 @@
            sodipodi:nodetypes="sscsccscss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22139"
          width="11.999998"
          height="12.000007"
@@ -1890,7 +1890,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22182-0"
          width="24"
          height="24.000017"
@@ -1923,7 +1923,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22184-8"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="park-12"
@@ -1947,7 +1947,7 @@
            sodipodi:nodetypes="cccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22186-1"
          width="11.999998"
          height="12.000007"
@@ -1976,7 +1976,7 @@
            sodipodi:nodetypes="scsscccsscsscccccccsccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22188-6"
          width="24"
          height="24.000017"
@@ -2009,7 +2009,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22190-5"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="park2-12"
@@ -2033,7 +2033,7 @@
            sodipodi:nodetypes="ccscsccccccccscscscccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22192-1"
          width="11.999998"
          height="12.000007"
@@ -2069,7 +2069,7 @@
          height="24.000017"
          width="24"
          id="rect22194"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="lodging-18"
@@ -2093,7 +2093,7 @@
            sodipodi:nodetypes="ssssscsccccsscscsssccssssss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22196"
          width="18.000017"
          height="18.000031"
@@ -2127,7 +2127,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22198"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="museum-24"
@@ -2157,7 +2157,7 @@
          height="24.000017"
          width="24"
          id="rect22242"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="museum-18"
@@ -2182,7 +2182,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22244"
          width="18.000017"
          height="18.000031"
@@ -2217,7 +2217,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22246"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="monument-24"
@@ -2246,7 +2246,7 @@
          height="24.000017"
          width="24"
          id="rect22248"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="monument-18"
@@ -2269,7 +2269,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;stroke:none;stroke-width:3;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22250"
          width="18.000017"
          height="18.000031"
@@ -2302,7 +2302,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22252"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="zoo-24"
@@ -2333,7 +2333,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22254"
          width="24"
          height="24.000017"
@@ -2366,7 +2366,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22256"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="zoo-12"
@@ -2389,7 +2389,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22258"
          width="11.999998"
          height="12.000007"
@@ -2414,7 +2414,7 @@
          d="m 170.3,1198.3622 c -0.253,0 -0.3,0.5596 -0.3,1 l 0,2 c 0,2.0312 2,3.0625 4,3 l 0,8 c -1,-2 -4,-5 -7,-4 0,0 2.5,6 7.5,6 5,0 7.5,-6 7.5,-6 -3,-1 -6,2 -7,4 l 0,-8 c 2,0.062 4,-0.9688 4,-3 l 0,-2 c 0,-0.4404 -0.0468,-1 -0.3,-1 -0.19292,0 -0.42562,0.2256 -0.7,0.5 l -1.5,1.5 -1.5,-1.6875 c -0.15657,-0.1761 -0.24696,-0.3125 -0.5,-0.3125 -0.25305,0 -0.34343,0.1364 -0.5,0.3125 l -1.5,1.6875 -1.5,-1.5 c -0.27438,-0.2744 -0.50708,-0.5 -0.7,-0.5 z"
          style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22282"
          width="24"
          height="24.000017"
@@ -2455,7 +2455,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22284"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="garden-12"
@@ -2477,7 +2477,7 @@
            id="path6080-4-3" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22286"
          width="11.999998"
          height="12.000007"
@@ -2509,7 +2509,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22288"
          width="24"
          height="24.000017"
@@ -2543,7 +2543,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22290"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="campsite-12"
@@ -2567,7 +2567,7 @@
            sodipodi:nodetypes="cccsssccsssccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22292"
          width="11.999998"
          height="12.000007"
@@ -2606,7 +2606,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22282-3"
          width="24"
          height="24.000017"
@@ -2639,7 +2639,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22284-1"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="school-12"
@@ -2663,7 +2663,7 @@
            sodipodi:nodetypes="ssssssssssccccccccccccccsccccccscssccccsscccccss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22286-0"
          width="11.999998"
          height="12.000007"
@@ -2698,7 +2698,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22288-9"
          width="24"
          height="24.000017"
@@ -2733,7 +2733,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22290-3"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="college-12"
@@ -2758,7 +2758,7 @@
            sodipodi:nodetypes="ccccccccccccsccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22292-2"
          width="11.999998"
          height="12.000007"
@@ -2792,7 +2792,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22294"
          width="24"
          height="24.000017"
@@ -2827,7 +2827,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22296"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="library-12"
@@ -2852,7 +2852,7 @@
            sodipodi:nodetypes="ccccsccscccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22298"
          width="11.999998"
          height="12.000007"
@@ -2890,7 +2890,7 @@
          height="24.000017"
          width="24"
          id="rect22300"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="hospital-18"
@@ -2916,7 +2916,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22302"
          width="18.000017"
          height="18.000031"
@@ -2956,7 +2956,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22304"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="pharmacy-24"
@@ -2980,7 +2980,7 @@
            sodipodi:nodetypes="ssssssscsssccscccsccscc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22282-1"
          width="24"
          height="24.000017"
@@ -3017,7 +3017,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22284-6"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="pharmacy-12"
@@ -3041,7 +3041,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22286-3"
          width="11.999998"
          height="12.000007"
@@ -3070,7 +3070,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22288-7"
          width="24"
          height="24.000017"
@@ -3104,7 +3104,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22290-1"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="cinema-12"
@@ -3126,7 +3126,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22292-1"
          width="11.999998"
          height="12.000007"
@@ -3158,7 +3158,7 @@
            sodipodi:nodetypes="scsscccssccsscsccsccsccsccscsssscsssc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22282-0"
          width="24"
          height="24.000017"
@@ -3192,7 +3192,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22284-4"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="restaurant-12"
@@ -3216,7 +3216,7 @@
            sodipodi:nodetypes="cccsccscccccccccccssccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22286-6"
          width="11.999998"
          height="12.000007"
@@ -3245,7 +3245,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22288-0"
          width="24"
          height="24.000017"
@@ -3279,7 +3279,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22290-8"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="cafe-12"
@@ -3303,7 +3303,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22292-9"
          width="11.999998"
          height="12.000007"
@@ -3333,7 +3333,7 @@
            sodipodi:nodetypes="ssccccccccccssssssccss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22294-0"
          width="24"
          height="24.000017"
@@ -3367,7 +3367,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22296-1"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="shop-12"
@@ -3391,7 +3391,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22298-4"
          width="11.999998"
          height="12.000007"
@@ -3425,7 +3425,7 @@
          height="24.000017"
          width="24"
          id="rect22300-6"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="fast-food-18"
@@ -3448,7 +3448,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22302-4"
          width="18.000017"
          height="18.000031"
@@ -3482,7 +3482,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22304-2"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="bar-24"
@@ -3512,7 +3512,7 @@
          height="24.000017"
          width="24"
          id="rect22415"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="bar-18"
@@ -3536,7 +3536,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22417"
          width="18.000017"
          height="18.000031"
@@ -3571,7 +3571,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22419"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="bank-24"
@@ -3604,7 +3604,7 @@
          height="24.000017"
          width="24"
          id="rect22421"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="bank-18"
@@ -3629,7 +3629,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22423"
          width="18.000017"
          height="18.000031"
@@ -3664,7 +3664,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22425"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="grocery-24"
@@ -3694,7 +3694,7 @@
          height="24.000017"
          width="24"
          id="rect22427"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="grocery-18"
@@ -3719,7 +3719,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22429"
          width="18.000017"
          height="18.000031"
@@ -3754,7 +3754,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22431"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="post-24"
@@ -3779,7 +3779,7 @@
            sodipodi:nodetypes="ccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22282-8"
          width="24"
          height="24.000017"
@@ -3814,7 +3814,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22284-8"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="post-12"
@@ -3835,7 +3835,7 @@
          d="m 440,1053.3622 4.5,3 4.5,-3 z m 0,1 0,4.5 c 0,0.25 0.3,0.5 0.5,0.5 l 8,0 c 0.2,0 0.55423,-0.256 0.5,-0.5 l 3e-5,-4.5 -4.50003,3.5 z"
          style="color:#000000;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22286-1"
          width="11.999998"
          height="12.000007"
@@ -3868,7 +3868,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22288-1"
          width="24"
          height="24.000017"
@@ -3902,7 +3902,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22290-37"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="fire-station-12"
@@ -3927,7 +3927,7 @@
            sodipodi:nodetypes="cccsssccccsssc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22292-6"
          width="11.999998"
          height="12.000007"
@@ -3956,7 +3956,7 @@
            sodipodi:nodetypes="ccccsscsssssscssssscccssssccccsssscccss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22294-4"
          width="24"
          height="24.000017"
@@ -3991,7 +3991,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22296-2"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="town-hall-12"
@@ -4016,7 +4016,7 @@
            sodipodi:nodetypes="ccccssccccccssscccccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22298-3"
          width="11.999998"
          height="12.000007"
@@ -4050,7 +4050,7 @@
          height="24.000017"
          width="24"
          id="rect22300-0"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="police-18"
@@ -4075,7 +4075,7 @@
            sodipodi:nodetypes="ccccccccsssccsccccscccsc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22302-3"
          width="18.000017"
          height="18.000031"
@@ -4110,7 +4110,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22304-3"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="prison-24"
@@ -4141,7 +4141,7 @@
          height="24.000017"
          width="24"
          id="rect22526"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="prison-18"
@@ -4166,7 +4166,7 @@
            sodipodi:nodetypes="ccccccsccccscccccscccccscccccccccccccccccccccccccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22528"
          width="18.000017"
          height="18.000031"
@@ -4201,7 +4201,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22530"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="embassy-24"
@@ -4232,7 +4232,7 @@
          height="24.000017"
          width="24"
          id="rect22532"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="pitch-24"
@@ -4256,7 +4256,7 @@
            sodipodi:nodetypes="ssssscssccsssssccssssccssssccssc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22282-18"
          width="24"
          height="24.000017"
@@ -4291,7 +4291,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22284-67"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="pitch-12"
@@ -4322,7 +4322,7 @@
            height="12.000007"
            width="11.999998"
            id="rect22286-5"
-           style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+           style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
     </g>
     <g
@@ -4348,7 +4348,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22288-5"
          width="24"
          height="24.000017"
@@ -4382,7 +4382,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22290-5"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="soccer-12"
@@ -4407,7 +4407,7 @@
            sodipodi:nodetypes="sssssscsssccsssscsccsscsssssssssssss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22292-98"
          width="11.999998"
          height="12.000007"
@@ -4438,7 +4438,7 @@
            id="path14961" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22294-1"
          width="24"
          height="24.000017"
@@ -4472,7 +4472,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22296-3"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="america-football-12"
@@ -4496,7 +4496,7 @@
            sodipodi:nodetypes="scscsccccccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22298-6"
          width="11.999998"
          height="12.000007"
@@ -4530,7 +4530,7 @@
          height="24.000017"
          width="24"
          id="rect22300-3"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="tennis-18"
@@ -4554,7 +4554,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22302-7"
          width="18.000017"
          height="18.000031"
@@ -4589,7 +4589,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22304-1"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="basketball-24"
@@ -4617,7 +4617,7 @@
          height="24.000017"
          width="24"
          id="rect22579"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="basketball-18"
@@ -4640,7 +4640,7 @@
            id="rect5769-7-5" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22581"
          width="18.000017"
          height="18.000031"
@@ -4673,7 +4673,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22583"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="baseball-24"
@@ -4702,7 +4702,7 @@
          height="24.000017"
          width="24"
          id="rect22585"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="baseball-18"
@@ -4726,7 +4726,7 @@
            sodipodi:nodetypes="cscccccccccccccsssss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22587"
          width="18.000017"
          height="18.000031"
@@ -4760,7 +4760,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22589"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="golf-24"
@@ -4789,7 +4789,7 @@
          height="24.000017"
          width="24"
          id="rect22591"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="golf-18"
@@ -4813,7 +4813,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22593"
          width="18.000017"
          height="18.000031"
@@ -4847,7 +4847,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22595"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="swimming-24"
@@ -4858,7 +4858,7 @@
       <g
          id="g21381" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22597"
          width="24"
          height="24.000017"
@@ -4903,7 +4903,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22599"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="swimming-12"
@@ -4928,7 +4928,7 @@
            sodipodi:nodetypes="cccccccccccccccssscccccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22601"
          width="11.999998"
          height="12.000007"
@@ -4957,7 +4957,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22603"
          width="24"
          height="24.000017"
@@ -4990,7 +4990,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22605"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="cricket-12"
@@ -5011,7 +5011,7 @@
          style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          sodipodi:nodetypes="csccccccccccsssss" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22607"
          width="11.999998"
          height="12.000007"
@@ -5046,7 +5046,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22609"
          width="24"
          height="24.000017"
@@ -5080,7 +5080,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22611"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="skiing-12"
@@ -5103,7 +5103,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22613"
          width="11.999998"
          height="12.000007"
@@ -5139,7 +5139,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22075-7"
          width="24"
          height="24.000017"
@@ -5176,7 +5176,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22077-6"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="airport-12"
@@ -5204,7 +5204,7 @@
            sodipodi:nodetypes="cccccccccccccssscc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22079-3"
          width="11.999998"
          height="12.000007"
@@ -5233,7 +5233,7 @@
            sodipodi:nodetypes="sssscsscccssscccccsssccccccssscsssssss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22081-2"
          width="24"
          height="24.000017"
@@ -5266,7 +5266,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22083-9"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="heliport-12"
@@ -5290,7 +5290,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22085-9"
          width="11.999998"
          height="12.000007"
@@ -5325,7 +5325,7 @@
          height="24.000017"
          width="24"
          id="rect22087-8"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="rail-underground-18"
@@ -5349,7 +5349,7 @@
            sodipodi:nodetypes="cccccccssssccccccccccssssssssss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22089-9"
          width="18.000017"
          height="18.000031"
@@ -5383,7 +5383,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22091-7"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="rail-above-24"
@@ -5413,7 +5413,7 @@
          height="24.000017"
          width="24"
          id="rect22164"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="rail-above-18"
@@ -5438,7 +5438,7 @@
            sodipodi:nodetypes="ccssssccccccccccssssssssssccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22166"
          width="18.000017"
          height="18.000031"
@@ -5470,7 +5470,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22168"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="bus-24"
@@ -5511,7 +5511,7 @@
          height="24.000017"
          width="24"
          id="rect22170"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="bus-18"
@@ -5534,7 +5534,7 @@
            id="path8522-6-8-58" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22172"
          width="18.000017"
          height="18.000031"
@@ -5567,7 +5567,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22174"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="fuel-24"
@@ -5601,7 +5601,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22176"
          width="24"
          height="24.000017"
@@ -5628,7 +5628,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22180"
          width="11.999998"
          height="12.000007"
@@ -5662,7 +5662,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22190"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <g
          style="font-size:14px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-indent:0;text-align:center;text-decoration:none;line-height:125%;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:middle;color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Open Sans;-inkscape-font-specification:Open Sans Bold"
          id="text6718-0" />
@@ -5691,7 +5691,7 @@
            sodipodi:nodetypes="cccccccccccccccccccssssssssss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect24861"
          width="24"
          height="24.000017"
@@ -5727,7 +5727,7 @@
          height="18.000031"
          width="18.000017"
          id="rect24871"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="rail-12"
@@ -5751,7 +5751,7 @@
            id="path24879" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect24881"
          width="11.999998"
          height="12.000007"
@@ -5778,7 +5778,7 @@
          id="rect7223-2-4-9-4-2-3"
          inkscape:connector-curvature="0" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22178-6-7"
          width="18.000017"
          height="18.000031"
@@ -6042,7 +6042,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22188"
          width="24"
          height="24.000017"
@@ -6055,7 +6055,7 @@
        inkscape:export-xdpi="89.996864"
        inkscape:export-ydpi="89.996864">
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22085"
          width="11.999998"
          height="12.000007"
@@ -6117,7 +6117,7 @@
          id="path8601"
          inkscape:connector-curvature="0" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22192"
          width="11.999998"
          height="12.000007"
@@ -6137,7 +6137,7 @@
          transform="translate(0,6)"
          id="g15948" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22182"
          width="24"
          height="24.000017"
@@ -6191,7 +6191,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22184"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="circle-stroked-24"
@@ -6240,7 +6240,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect13509"
          width="24.000017"
          height="24.000034"
@@ -6275,7 +6275,7 @@
          height="24.000017"
          width="24"
          id="rect6156"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        style="display:inline"
@@ -6335,7 +6335,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22190-58-4"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        transform="translate(0,-24.000003)"
@@ -6361,7 +6361,7 @@
            sodipodi:nodetypes="sssccccccccccccccccccssss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22192-14-7-4"
          width="11.999998"
          height="12.000007"
@@ -6498,7 +6498,7 @@
          style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;opacity:0.3;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
          sodipodi:nodetypes="ccccccccccccccccccccc" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22069"
          width="24"
          height="24.000017"
@@ -6523,7 +6523,7 @@
          height="18.000031"
          width="18.000017"
          id="rect21975-5"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          inkscape:connector-curvature="0"
          style="opacity:0.3;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
@@ -6579,7 +6579,7 @@
          d="m 761,3 -7.5,6.5 c -0.36201,0.3017 -0.5,0.5 -0.5,0.75 0,0.4959 0.5,0.75 1,0.75 l 1,0 0,8 c 0,0.554 0.446,1 1,1 l 13,0 c 0.554,0 1,-0.446 1,-1 l 0,-8 1,0 c 0.5,0 1,-0.2541 1,-0.75 C 772,10 771.86201,9.8017 771.5,9.5 L 764,3 z m -2,9 7,0 0,0.5 -7,0 z m 0,2 7,0 0,0.5 -7,0 z m 0,2 7,0 0,0.5 -7,0 z m 0,2 7,0 0,0.5 -7,0 z"
          style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;opacity:0.29999999999999999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect13515-8"
          width="24.000017"
          height="24.000034"
@@ -6643,7 +6643,7 @@
          height="18.000031"
          width="18.000017"
          id="rect13488-3-7"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="industrial-24"
@@ -6669,7 +6669,7 @@
          height="24.000034"
          width="24.000017"
          id="rect13515-8-6"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="g12922">
@@ -6798,7 +6798,7 @@
          transform="translate(-120,1050.3622)"
          id="path5406" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect13488-3-7-0"
          width="18.000017"
          height="18.000031"
@@ -6824,7 +6824,7 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ssccccccssscccccccccccccccccccccccccccccccccccccccc" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect13515-8-6-0"
          width="24.000017"
          height="24.000034"
@@ -6854,7 +6854,7 @@
          height="24.000017"
          width="24"
          id="rect5691"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="waste-basket-18"
@@ -6874,7 +6874,7 @@
          d="m 349.518,1268.3622 c -0.20411,0 -0.268,0.1643 -0.268,0.3684 l 0,1.6316 -2.51315,0 c -0.40822,0 -0.73685,0.092 -0.73685,0.5 0,0.4083 0.32863,0.5 0.73685,0.5 l 9.52631,0 c 0.40821,0 0.73684,-0.092 0.73684,-0.5 0,-0.4082 -0.32863,-0.5 -0.73684,-0.5 l -2.51316,0 0,-1.6316 c 0,-0.2041 -0.16389,-0.3684 -0.368,-0.3684 z m 0.482,0.7368 3,0 0,1.2632 -3,0 z m -3.26315,3.2632 c -0.40822,0 -0.78834,0.3343 -0.72122,0.7369 l 1.40542,8.5263 c 0.0664,0.4027 0.32863,0.7368 0.73685,0.7368 l 6.63157,0 c 0.40822,0 0.66972,-0.3342 0.73685,-0.7368 l 1.45805,-8.5263 c 0.0688,-0.4023 -0.313,-0.7369 -0.72121,-0.7369 z"
          id="path5652" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect5693"
          width="18.000017"
          height="18.000031"
@@ -6899,7 +6899,7 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccccccccccccccccc" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22536-5"
          width="11.999998"
          height="12.000007"
@@ -6926,7 +6926,7 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ssssssssssssccsccccsccssssccccccccss" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect5691-0"
          width="24"
          height="24.000017"
@@ -6959,7 +6959,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22284-6-5-5"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="danger-24"
@@ -6982,7 +6982,7 @@
          height="24.000017"
          width="24"
          id="rect5537"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="danger-12"
@@ -7002,7 +7002,7 @@
          d="m 599.5,1051.3622 -1.5,1.5 c 0,0 0,1.3333 0,2 l 1,1 c 0,0.1667 0,0.5 0,0.5 l 1.5,1 1.5,-1 0,-0.5 1,-1 0,-2 -1.5,-1.5 z m -0.5,2 1,0 0,0.5 -1,0 z m 2,0 1,0 0,0.5 -1,0 z m -5,3 0,1 0.56039,0.2802 2.43961,1.2198 -3,1.5 0,1 0.5,0 5.5,-2.5 3,-1.5 0,-1 -0.5,0 -3,1.5 -0.5,0.5 -1,0 -0.5,-0.5 -3,-1.5 z m 7,3 -1.5,0.5 3,1.5 0.5,0 0,-1 z"
          style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22286-3-7-3"
          width="11.999998"
          height="12.000007"
@@ -7040,7 +7040,7 @@
          height="24.000017"
          width="24"
          id="rect22288-7-6"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        style="display:inline"
@@ -7068,7 +7068,7 @@
            sodipodi:nodetypes="ccccccccccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22290-1-7"
          width="18.000017"
          height="18.000031"
@@ -7104,7 +7104,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22292-1-0"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        style="display:inline"
@@ -7130,7 +7130,7 @@
            sodipodi:nodetypes="cccsscccccsscccccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect7313"
          width="24"
          height="24.000017"
@@ -7166,7 +7166,7 @@
          height="18.000031"
          width="18.000017"
          id="rect7315"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        style="display:inline"
@@ -7192,7 +7192,7 @@
            sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect7317"
          width="11.999998"
          height="12.000007"
@@ -7228,7 +7228,7 @@
          height="24.000017"
          width="24"
          id="rect7319"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        style="display:inline"
@@ -7254,7 +7254,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect7321"
          width="18.000017"
          height="18.000031"
@@ -7292,7 +7292,7 @@
          height="12.000007"
          width="11.999998"
          id="rect7323"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        style="display:inline"
@@ -7318,7 +7318,7 @@
            sodipodi:nodetypes="scccccccssscccccscccccscccsscccccscccccscccs" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect7325"
          width="24"
          height="24.000017"
@@ -7354,7 +7354,7 @@
          height="18.000031"
          width="18.000017"
          id="rect7327"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        style="display:inline"
@@ -7380,7 +7380,7 @@
            sodipodi:nodetypes="ccccccccccccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect7329"
          width="11.999998"
          height="12.000007"
@@ -7406,7 +7406,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22284-6-5"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          id="path5792"
          d="m 582.5,1076.3622 -0.5,0.5 0,3 -2,2.5 0,8 6,0 0,-8 -2,-2.5 0,-3 -0.5,-0.5 -1,0 z m 4.5,6 0,3 c 0,0 0,1 1,1 l 1,0 0,3 -1.5,0.5 -0.5,0.5 5,0 -0.5,-0.5 -1.5,-0.5 0,-3 1,0 c 1,0 1,-1 1,-1 l 0,-3 -5,0 z"
@@ -7427,7 +7427,7 @@
          transform="translate(-120,1050.3622)"
          id="path8755" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22286-3-7"
          width="11.999998"
          height="12.000007"
@@ -7454,7 +7454,7 @@
          id="path8739"
          sodipodi:nodetypes="cccccccccccccccccccccccccccccc" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22282-1-3"
          width="24"
          height="24.000017"
@@ -7487,7 +7487,7 @@
         <g
            id="g8816" />
         <rect
-           style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+           style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
            id="rect8822"
            width="24"
            height="24.000017"
@@ -7521,7 +7521,7 @@
         <g
            id="g8836" />
         <rect
-           style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+           style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
            id="rect8842"
            width="11.999998"
            height="12.000007"
@@ -7560,7 +7560,7 @@
            height="18.000031"
            width="18.000017"
            id="rect8832"
-           style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+           style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <path
          style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
@@ -7586,7 +7586,7 @@
          height="24.000017"
          width="24"
          id="rect22609-8"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          d="m 259,1304.8622 c 0,-3.5 -5,-9.5 -6.5,-11.5 -1.5,2 -6.5,8 -6.5,11.5 0,3.5 3.27126,6.5 6.5,6.5 3.22874,0 6.5,-3 6.5,-6.5 z"
@@ -7606,7 +7606,7 @@
          d="m 273.5,1305.3622 c -2.33186,0 -4.5,-2 -4.5,-4.5 0,-2.5278 3.41667,-7.0556 4.5,-8.5 1.08334,1.4444 4.5,5.9722 4.5,8.5 0,2.5 -2.16813,4.5 -4.5,4.5 z"
          style="color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;opacity:0.29999999999999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22611-2"
          width="18.000017"
          height="18.000031"
@@ -7630,7 +7630,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22613-5"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          sodipodi:nodetypes="sscss"
          inkscape:connector-curvature="0"
@@ -7665,7 +7665,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22611-2-1"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="wetland-24"
@@ -7673,7 +7673,7 @@
        inkscape:export-xdpi="89.996864"
        inkscape:export-ydpi="89.996864">
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22609-8-4"
          width="24"
          height="24.000017"
@@ -7701,7 +7701,7 @@
          transform="translate(-120,1050.3622)"
          id="path4812" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22613-5-9"
          width="11.999998"
          height="12.000007"
@@ -7719,7 +7719,7 @@
        inkscape:export-xdpi="89.996864"
        inkscape:export-ydpi="89.996864">
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect13488-3"
          width="18.000017"
          height="18.000031"
@@ -7761,7 +7761,7 @@
          height="18.000031"
          width="18.000017"
          id="rect5873"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        inkscape:export-ydpi="89.996864"
@@ -7781,7 +7781,7 @@
          height="24.000034"
          width="24.000017"
          id="rect5877"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          d="m 641,1077.3622 -7.5,6.5 c -0.3561,0.3086 -0.5,0.5 -0.5,0.75 0,0.4959 0.5,0.75 1,0.75 l 1,0 0,8 c 0,0.554 0.446,1 1,1 l 6.5,0 6.5,0 c 0.554,0 1,-0.446 1,-1 l 0,-8 1,0 c 0.5,0 1,-0.2541 1,-0.75 0,-0.25 -0.13799,-0.4483 -0.5,-0.75 l -7.5,-6.5 z"
@@ -7860,7 +7860,7 @@
          style="opacity:0.3;color:#000000;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          sodipodi:nodetypes="ccccccccccc" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22534"
          width="18.000017"
          height="18.000031"
@@ -7888,7 +7888,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22536"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          sodipodi:nodetypes="ccccccccccc"
          style="color:#000000;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
@@ -8155,7 +8155,7 @@
          height="18.000013"
          width="18"
          id="rect7662"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        style="display:inline"
@@ -8182,7 +8182,7 @@
          height="24.000017"
          width="24"
          id="rect7662-4"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="music-24"
@@ -8296,7 +8296,7 @@
          height="24.000017"
          width="24"
          id="rect7325-2"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="land-use-18"
@@ -8314,7 +8314,7 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect5989"
          width="18"
          height="18.000013"
@@ -8346,7 +8346,7 @@
          height="12.000009"
          width="12"
          id="rect5991"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="city-24"
@@ -8357,7 +8357,7 @@
          id="path9456"
          inkscape:connector-curvature="0" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect7325-2-7"
          width="24"
          height="24.000017"
@@ -8388,7 +8388,7 @@
          height="18.000013"
          width="18"
          id="rect5989-6"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="town-24"
@@ -8409,7 +8409,7 @@
          height="24.000017"
          width="24"
          id="rect7325-2-7-0"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
     <g
        id="town-12"
@@ -8426,7 +8426,7 @@
          height="12.000009"
          width="12"
          id="rect5991-0-4"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.46545455;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          d="m 676,1292.8622 -2,1.5 0,5 1.5,0 0,-1 1,0 0,1 1.5,0 0,-5 z m -1,2 2,0 0,0.5 -2,0 z m 4,0.5 0,5 1.5,0 0,-1 1,0 0,1 1.5,0 0,-5 -2,-1.5 z m 1,0.5 2,0 0,0.5 -2,0 z m -5,1 2,0 0,0.5 -2,0 z m 5,1 2,0 0,0.5 -2,0 z"
@@ -8444,7 +8444,7 @@
          id="path9067"
          sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect5989-6-0"
          width="18"
          height="18.000013"
@@ -8466,7 +8466,7 @@
          d="m 638,1319.3622 -4.5,4 c -0.5,0.5 0,1 0.5,1 l 1,0 0,5 1,0 1,0 0,-3 2,0 0,3 1,0 1,0 0,-5 1,0 c 0.5,0 1,-0.5 0.5,-1 l -4.5,-4 z m 9,3 -4.5,4 c -0.5,0.5 0,1 0.5,1 l 1,0 0,5 1,0 1,0 0,-3 2,0 0,3 1,0 1,0 0,-5 1,0 c 0.5,0 1,-0.5 0.5,-1 l -4.5,-4 z"
          id="path9528" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect7325-2-7-0-6"
          width="24"
          height="24.000017"
@@ -8487,7 +8487,7 @@
          id="path9461"
          inkscape:connector-curvature="0" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect5991-0"
          width="12"
          height="12.000009"
@@ -8509,7 +8509,7 @@
          d="m 676.5,1316.8622 -2.5,2.5 1,0 0,3 1,0 0,-1.5 1,0 0,1.5 1,0 0,-3 1,0 z m 4,2 -2,2 0,0.5 0.5,0 0,3 1,0 0,-1.5 1,0 0,1.5 1,0 0,-3 1,0 z"
          style="opacity:0.3;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect5991-0-4-1"
          width="12"
          height="12.000009"
@@ -8535,7 +8535,7 @@
          height="18.000013"
          width="18"
          id="rect5989-6-0-6"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          id="path9415"
          transform="translate(-120,1050.3622)"
@@ -8551,7 +8551,7 @@
          height="24.000017"
          width="24"
          id="rect7325-2-7-0-6-5"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <g
          id="g6587">
         <path
@@ -8586,7 +8586,7 @@
          height="12.000009"
          width="12"
          id="rect5991-0-4-1-1"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          sodipodi:nodetypes="ccccccccccccccccccccccc"
          inkscape:connector-curvature="0"
@@ -8605,7 +8605,7 @@
          d="m 667,1344.3622 0,8 4,0 0,-8 -1,-2 -2,0 z m -9.5,0 -2.5,3 1,0 0,5 9,0 0,-5 1,0 -2,-3 z"
          style="opacity:0.3;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect5989-6-0-6-5"
          width="18"
          height="18.000013"

--- a/src/marker-12.svg
+++ b/src/marker-12.svg
@@ -102,7 +102,7 @@
        inkscape:export-xdpi="89.996864"
        inkscape:export-ydpi="89.996864">
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22085"
          width="11.999998"
          height="12.000007"

--- a/src/marker-18.svg
+++ b/src/marker-18.svg
@@ -118,7 +118,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22083"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          sodipodi:nodetypes="sscss"
          inkscape:connector-curvature="0"

--- a/src/marker-24.svg
+++ b/src/marker-24.svg
@@ -130,7 +130,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22081"
          width="24"
          height="24.000017"

--- a/src/marker-stroked-12.svg
+++ b/src/marker-stroked-12.svg
@@ -119,7 +119,7 @@
            sodipodi:nodetypes="sscsssscss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22079"
          width="11.999998"
          height="12.000007"

--- a/src/marker-stroked-18.svg
+++ b/src/marker-stroked-18.svg
@@ -125,7 +125,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22077"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/marker-stroked-24.svg
+++ b/src/marker-stroked-24.svg
@@ -129,7 +129,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22075"
          width="24"
          height="24.000017"

--- a/src/minefield-18.svg
+++ b/src/minefield-18.svg
@@ -103,7 +103,7 @@
        inkscape:label="minefield-18"
        transform="translate(-576.00002,-88.000013)">
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect13486"
          width="18.000017"
          height="18.000031"

--- a/src/minefield-24.svg
+++ b/src/minefield-24.svg
@@ -114,7 +114,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect13513"
          width="24.000017"
          height="24.000034"

--- a/src/monument-12.svg
+++ b/src/monument-12.svg
@@ -122,7 +122,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22252"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/monument-18.svg
+++ b/src/monument-18.svg
@@ -120,7 +120,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;stroke:none;stroke-width:3;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22250"
          width="18.000017"
          height="18.000031"

--- a/src/monument-24.svg
+++ b/src/monument-24.svg
@@ -131,7 +131,7 @@
          height="24.000017"
          width="24"
          id="rect22248"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/museum-12.svg
+++ b/src/museum-12.svg
@@ -123,7 +123,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22246"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/museum-18.svg
+++ b/src/museum-18.svg
@@ -121,7 +121,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22244"
          width="18.000017"
          height="18.000031"

--- a/src/museum-24.svg
+++ b/src/museum-24.svg
@@ -131,7 +131,7 @@
          height="24.000017"
          width="24"
          id="rect22242"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/oil-well-12.svg
+++ b/src/oil-well-12.svg
@@ -122,7 +122,7 @@
            sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect7317"
          width="11.999998"
          height="12.000007"

--- a/src/oil-well-18.svg
+++ b/src/oil-well-18.svg
@@ -127,7 +127,7 @@
          height="18.000031"
          width="18.000017"
          id="rect7315"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/oil-well-24.svg
+++ b/src/oil-well-24.svg
@@ -130,7 +130,7 @@
            sodipodi:nodetypes="cccsscccccsscccccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect7313"
          width="24"
          height="24.000017"

--- a/src/park-12.svg
+++ b/src/park-12.svg
@@ -118,7 +118,7 @@
            sodipodi:nodetypes="cccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22186-1"
          width="11.999998"
          height="12.000007"

--- a/src/park-18.svg
+++ b/src/park-18.svg
@@ -125,7 +125,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22184-8"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/park-24.svg
+++ b/src/park-24.svg
@@ -128,7 +128,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22182-0"
          width="24"
          height="24.000017"

--- a/src/park2-12.svg
+++ b/src/park2-12.svg
@@ -118,7 +118,7 @@
            sodipodi:nodetypes="ccscsccccccccscscscccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22192-1"
          width="11.999998"
          height="12.000007"

--- a/src/park2-18.svg
+++ b/src/park2-18.svg
@@ -125,7 +125,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22190-5"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/park2-24.svg
+++ b/src/park2-24.svg
@@ -126,7 +126,7 @@
            sodipodi:nodetypes="scsscccsscsscccccccsccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22188-6"
          width="24"
          height="24.000017"

--- a/src/parking-18.svg
+++ b/src/parking-18.svg
@@ -126,7 +126,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22184"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/parking-24.svg
+++ b/src/parking-24.svg
@@ -105,7 +105,7 @@
          transform="translate(0,6)"
          id="g15948" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22182"
          width="24"
          height="24.000017"

--- a/src/parking-garage-12.svg
+++ b/src/parking-garage-12.svg
@@ -112,7 +112,7 @@
          id="path8601"
          inkscape:connector-curvature="0" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22192"
          width="11.999998"
          height="12.000007"

--- a/src/parking-garage-18.svg
+++ b/src/parking-garage-18.svg
@@ -125,7 +125,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22190"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <g
          style="font-size:14px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-indent:0;text-align:center;text-decoration:none;line-height:125%;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:middle;color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Open Sans;-inkscape-font-specification:Open Sans Bold"
          id="text6718-0" />

--- a/src/parking-garage-24.svg
+++ b/src/parking-garage-24.svg
@@ -116,7 +116,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22188"
          width="24"
          height="24.000017"

--- a/src/pharmacy-12.svg
+++ b/src/pharmacy-12.svg
@@ -121,7 +121,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22286-3"
          width="11.999998"
          height="12.000007"

--- a/src/pharmacy-18.svg
+++ b/src/pharmacy-18.svg
@@ -129,7 +129,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22284-6"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/pharmacy-24.svg
+++ b/src/pharmacy-24.svg
@@ -129,7 +129,7 @@
            sodipodi:nodetypes="ssssssscsssccscccsccscc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22282-1"
          width="24"
          height="24.000017"

--- a/src/pitch-12.svg
+++ b/src/pitch-12.svg
@@ -124,7 +124,7 @@
            height="12.000007"
            width="11.999998"
            id="rect22286-5"
-           style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+           style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
     </g>
   </g>

--- a/src/pitch-18.svg
+++ b/src/pitch-18.svg
@@ -126,7 +126,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22284-67"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/pitch-24.svg
+++ b/src/pitch-24.svg
@@ -125,7 +125,7 @@
            sodipodi:nodetypes="ssssscssccsssssccssssccssssccssc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22282-18"
          width="24"
          height="24.000017"

--- a/src/place-of-worship-12.svg
+++ b/src/place-of-worship-12.svg
@@ -116,7 +116,7 @@
         <g
            id="g8836" />
         <rect
-           style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+           style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
            id="rect8842"
            width="11.999998"
            height="12.000007"

--- a/src/place-of-worship-18.svg
+++ b/src/place-of-worship-18.svg
@@ -124,7 +124,7 @@
            height="18.000031"
            width="18.000017"
            id="rect8832"
-           style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+           style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <path
          style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"

--- a/src/place-of-worship-24.svg
+++ b/src/place-of-worship-24.svg
@@ -120,7 +120,7 @@
         <g
            id="g8816" />
         <rect
-           style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+           style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
            id="rect8822"
            width="24"
            height="24.000017"

--- a/src/police-12.svg
+++ b/src/police-12.svg
@@ -127,7 +127,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22304-3"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/police-18.svg
+++ b/src/police-18.svg
@@ -121,7 +121,7 @@
            sodipodi:nodetypes="ccccccccsssccsccccscccsc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22302-3"
          width="18.000017"
          height="18.000031"

--- a/src/police-24.svg
+++ b/src/police-24.svg
@@ -126,7 +126,7 @@
          height="24.000017"
          width="24"
          id="rect22300-0"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/post-12.svg
+++ b/src/post-12.svg
@@ -118,7 +118,7 @@
          d="m 440,1053.3622 4.5,3 4.5,-3 z m 0,1 0,4.5 c 0,0.25 0.3,0.5 0.5,0.5 l 8,0 c 0.2,0 0.55423,-0.256 0.5,-0.5 l 3e-5,-4.5 -4.50003,3.5 z"
          style="color:#000000;fill:#444444;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22286-1"
          width="11.999998"
          height="12.000007"

--- a/src/post-18.svg
+++ b/src/post-18.svg
@@ -126,7 +126,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22284-8"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/post-24.svg
+++ b/src/post-24.svg
@@ -122,7 +122,7 @@
            sodipodi:nodetypes="ccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22282-8"
          width="24"
          height="24.000017"

--- a/src/prison-12.svg
+++ b/src/prison-12.svg
@@ -127,7 +127,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22530"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/prison-18.svg
+++ b/src/prison-18.svg
@@ -121,7 +121,7 @@
            sodipodi:nodetypes="ccccccsccccscccccscccccscccccccccccccccccccccccccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22528"
          width="18.000017"
          height="18.000031"

--- a/src/prison-24.svg
+++ b/src/prison-24.svg
@@ -128,7 +128,7 @@
          height="24.000017"
          width="24"
          id="rect22526"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/rail-above-12.svg
+++ b/src/rail-above-12.svg
@@ -120,7 +120,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22168"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/rail-above-18.svg
+++ b/src/rail-above-18.svg
@@ -121,7 +121,7 @@
            sodipodi:nodetypes="ccssssccccccccccssssssssssccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22166"
          width="18.000017"
          height="18.000031"

--- a/src/rail-above-24.svg
+++ b/src/rail-above-24.svg
@@ -123,7 +123,7 @@
          height="24.000017"
          width="24"
          id="rect22164"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/rail-underground-12.svg
+++ b/src/rail-underground-12.svg
@@ -122,7 +122,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22091-7"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/rail-underground-18.svg
+++ b/src/rail-underground-18.svg
@@ -120,7 +120,7 @@
            sodipodi:nodetypes="cccccccssssccccccccccssssssssss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22089-9"
          width="18.000017"
          height="18.000031"

--- a/src/rail-underground-24.svg
+++ b/src/rail-underground-24.svg
@@ -123,7 +123,7 @@
          height="24.000017"
          width="24"
          id="rect22087-8"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/religious-christian-12.svg
+++ b/src/religious-christian-12.svg
@@ -117,7 +117,7 @@
            sodipodi:nodetypes="cscccccccccccssc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22079-8"
          width="11.999998"
          height="12.000007"

--- a/src/religious-christian-18.svg
+++ b/src/religious-christian-18.svg
@@ -126,7 +126,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22077-2"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/religious-christian-24.svg
+++ b/src/religious-christian-24.svg
@@ -121,7 +121,7 @@
            sodipodi:nodetypes="sscccccccccccss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22075-4"
          width="24"
          height="24.000017"

--- a/src/religious-jewish-12.svg
+++ b/src/religious-jewish-12.svg
@@ -122,7 +122,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22091"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/religious-jewish-18.svg
+++ b/src/religious-jewish-18.svg
@@ -118,7 +118,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22089"
          width="18.000017"
          height="18.000031"

--- a/src/religious-jewish-24.svg
+++ b/src/religious-jewish-24.svg
@@ -126,7 +126,7 @@
          height="24.000017"
          width="24"
          id="rect22087"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/religious-muslim-12.svg
+++ b/src/religious-muslim-12.svg
@@ -117,7 +117,7 @@
            sodipodi:nodetypes="csscsssccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22085-4"
          width="11.999998"
          height="12.000007"

--- a/src/religious-muslim-18.svg
+++ b/src/religious-muslim-18.svg
@@ -125,7 +125,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22083-8"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/religious-muslim-24.svg
+++ b/src/religious-muslim-24.svg
@@ -119,7 +119,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22081-5"
          width="24"
          height="24.000017"

--- a/src/restaurant-12.svg
+++ b/src/restaurant-12.svg
@@ -121,7 +121,7 @@
            sodipodi:nodetypes="cccsccscccccccccccssccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22286-6"
          width="11.999998"
          height="12.000007"

--- a/src/restaurant-18.svg
+++ b/src/restaurant-18.svg
@@ -126,7 +126,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22284-4"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/restaurant-24.svg
+++ b/src/restaurant-24.svg
@@ -132,7 +132,7 @@
            sodipodi:nodetypes="scsscccssccsscsccsccsccsccscsssscsssc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22282-0"
          width="24"
          height="24.000017"

--- a/src/roadblock-18.svg
+++ b/src/roadblock-18.svg
@@ -110,7 +110,7 @@
          height="18.000031"
          width="18.000017"
          id="rect21975-5"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          inkscape:connector-curvature="0"
          style="opacity:0.3;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"

--- a/src/roadblock-24.svg
+++ b/src/roadblock-24.svg
@@ -116,7 +116,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect13509"
          width="24.000017"
          height="24.000034"

--- a/src/school-12.svg
+++ b/src/school-12.svg
@@ -121,7 +121,7 @@
            sodipodi:nodetypes="ssssssssssccccccccccccccsccccccscssccccsscccccss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22286-0"
          width="11.999998"
          height="12.000007"

--- a/src/school-18.svg
+++ b/src/school-18.svg
@@ -124,7 +124,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22284-1"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/school-24.svg
+++ b/src/school-24.svg
@@ -131,7 +131,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22282-3"
          width="24"
          height="24.000017"

--- a/src/shop-12.svg
+++ b/src/shop-12.svg
@@ -121,7 +121,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22298-4"
          width="11.999998"
          height="12.000007"

--- a/src/shop-18.svg
+++ b/src/shop-18.svg
@@ -126,7 +126,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22296-1"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/shop-24.svg
+++ b/src/shop-24.svg
@@ -130,7 +130,7 @@
            sodipodi:nodetypes="ssccccccccccssssssccss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22294-0"
          width="24"
          height="24.000017"

--- a/src/skiing-12.svg
+++ b/src/skiing-12.svg
@@ -116,7 +116,7 @@
            inkscape:connector-curvature="0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22613"
          width="11.999998"
          height="12.000007"

--- a/src/skiing-18.svg
+++ b/src/skiing-18.svg
@@ -125,7 +125,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22611"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/skiing-24.svg
+++ b/src/skiing-24.svg
@@ -127,7 +127,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22609"
          width="24"
          height="24.000017"

--- a/src/slaughterhouse-12.svg
+++ b/src/slaughterhouse-12.svg
@@ -129,7 +129,7 @@
          height="12.000007"
          width="11.999998"
          id="rect7323"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/slaughterhouse-18.svg
+++ b/src/slaughterhouse-18.svg
@@ -122,7 +122,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect7321"
          width="18.000017"
          height="18.000031"

--- a/src/slaughterhouse-24.svg
+++ b/src/slaughterhouse-24.svg
@@ -135,7 +135,7 @@
          height="24.000017"
          width="24"
          id="rect7319"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/soccer-12.svg
+++ b/src/soccer-12.svg
@@ -118,7 +118,7 @@
            sodipodi:nodetypes="sssssscsssccsssscsccsscsssssssssssss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22292-98"
          width="11.999998"
          height="12.000007"

--- a/src/soccer-18.svg
+++ b/src/soccer-18.svg
@@ -125,7 +125,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22290-5"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/soccer-24.svg
+++ b/src/soccer-24.svg
@@ -126,7 +126,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22288-5"
          width="24"
          height="24.000017"

--- a/src/square-12.svg
+++ b/src/square-12.svg
@@ -121,7 +121,7 @@
          height="12.000007"
          width="11.999998"
          id="rect21989"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/square-18.svg
+++ b/src/square-18.svg
@@ -126,7 +126,7 @@
            ry="1.0000174" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect21987"
          width="18.000017"
          height="18.000031"

--- a/src/square-24.svg
+++ b/src/square-24.svg
@@ -130,7 +130,7 @@
          height="24.000017"
          width="24"
          id="rect21985"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/square-stroked-12.svg
+++ b/src/square-stroked-12.svg
@@ -118,7 +118,7 @@
            sodipodi:nodetypes="sssssssssccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect21983"
          width="11.999998"
          height="12.000007"

--- a/src/square-stroked-18.svg
+++ b/src/square-stroked-18.svg
@@ -123,7 +123,7 @@
          height="18.000031"
          width="18.000017"
          id="rect21981"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/square-stroked-24.svg
+++ b/src/square-stroked-24.svg
@@ -130,7 +130,7 @@
            id="rect11284" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect21979"
          width="24"
          height="24.000017"

--- a/src/star-12.svg
+++ b/src/star-12.svg
@@ -123,7 +123,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22061"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/star-18.svg
+++ b/src/star-18.svg
@@ -120,7 +120,7 @@
            id="path4749-2-8-0" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22059"
          width="18.000017"
          height="18.000031"

--- a/src/star-24.svg
+++ b/src/star-24.svg
@@ -135,7 +135,7 @@
          height="24.000017"
          width="24"
          id="rect22057"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/star-stroked-12.svg
+++ b/src/star-stroked-12.svg
@@ -121,7 +121,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22067"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/star-stroked-18.svg
+++ b/src/star-stroked-18.svg
@@ -120,7 +120,7 @@
            sodipodi:nodetypes="cccccccccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22065"
          width="18.000017"
          height="18.000031"

--- a/src/star-stroked-24.svg
+++ b/src/star-stroked-24.svg
@@ -135,7 +135,7 @@
          height="24.000017"
          width="24"
          id="rect22063"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/swimming-12.svg
+++ b/src/swimming-12.svg
@@ -118,7 +118,7 @@
            sodipodi:nodetypes="cccccccccccccccssscccccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22601"
          width="11.999998"
          height="12.000007"

--- a/src/swimming-18.svg
+++ b/src/swimming-18.svg
@@ -124,7 +124,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22599"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/swimming-24.svg
+++ b/src/swimming-24.svg
@@ -108,7 +108,7 @@
       <g
          id="g21381" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22597"
          width="24"
          height="24.000017"

--- a/src/tennis-12.svg
+++ b/src/tennis-12.svg
@@ -123,7 +123,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22304-1"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/tennis-18.svg
+++ b/src/tennis-18.svg
@@ -120,7 +120,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22302-7"
          width="18.000017"
          height="18.000031"

--- a/src/tennis-24.svg
+++ b/src/tennis-24.svg
@@ -130,7 +130,7 @@
          height="24.000017"
          width="24"
          id="rect22300-3"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/toilets-12.svg
+++ b/src/toilets-12.svg
@@ -123,7 +123,7 @@
          height="24.000017"
          width="24"
          id="rect7662-4"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/toilets-18.svg
+++ b/src/toilets-18.svg
@@ -120,7 +120,7 @@
          height="18.000013"
          width="18"
          id="rect7662"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/toilets-24.svg
+++ b/src/toilets-24.svg
@@ -120,7 +120,7 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ssssssssssssccsccccsccssssccccccccss" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect5691-0"
          width="24"
          height="24.000017"

--- a/src/town-12.svg
+++ b/src/town-12.svg
@@ -115,7 +115,7 @@
          height="12.000009"
          width="12"
          id="rect5991-0-4"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.46545455;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          d="m 676,1292.8622 -2,1.5 0,5 1.5,0 0,-1 1,0 0,1 1.5,0 0,-5 z m -1,2 2,0 0,0.5 -2,0 z m 4,0.5 0,5 1.5,0 0,-1 1,0 0,1 1.5,0 0,-5 -2,-1.5 z m 1,0.5 2,0 0,0.5 -2,0 z m -5,1 2,0 0,0.5 -2,0 z m 5,1 2,0 0,0.5 -2,0 z"

--- a/src/town-18.svg
+++ b/src/town-18.svg
@@ -110,7 +110,7 @@
          id="path9067"
          sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect5989-6-0"
          width="18"
          height="18.000013"

--- a/src/town-24.svg
+++ b/src/town-24.svg
@@ -127,7 +127,7 @@
          height="24.000017"
          width="24"
          id="rect7325-2-7-0"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/town-hall-12.svg
+++ b/src/town-hall-12.svg
@@ -122,7 +122,7 @@
            sodipodi:nodetypes="ccccssccccccssscccccccccccccccccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22298-3"
          width="11.999998"
          height="12.000007"

--- a/src/town-hall-18.svg
+++ b/src/town-hall-18.svg
@@ -126,7 +126,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22296-2"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/town-hall-24.svg
+++ b/src/town-hall-24.svg
@@ -121,7 +121,7 @@
            sodipodi:nodetypes="ccccsscsssssscssssscccssssccccsssscccss" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22294-4"
          width="24"
          height="24.000017"

--- a/src/triangle-12.svg
+++ b/src/triangle-12.svg
@@ -117,7 +117,7 @@
            style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22055"
          width="11.999998"
          height="12.000007"

--- a/src/triangle-18.svg
+++ b/src/triangle-18.svg
@@ -125,7 +125,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22053"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/triangle-24.svg
+++ b/src/triangle-24.svg
@@ -124,7 +124,7 @@
            sodipodi:nodetypes="cccsccsccc" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22051"
          width="24"
          height="24.000017"

--- a/src/triangle-stroked-12.svg
+++ b/src/triangle-stroked-12.svg
@@ -116,7 +116,7 @@
            transform="translate(-120,1050.3622)" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22049"
          width="11.999998"
          height="12.000007"

--- a/src/triangle-stroked-18.svg
+++ b/src/triangle-stroked-18.svg
@@ -123,7 +123,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22047"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/triangle-stroked-24.svg
+++ b/src/triangle-stroked-24.svg
@@ -124,7 +124,7 @@
            style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22045"
          width="24"
          height="24.000017"

--- a/src/village-12.svg
+++ b/src/village-12.svg
@@ -109,7 +109,7 @@
          d="m 676.5,1316.8622 -2.5,2.5 1,0 0,3 1,0 0,-1.5 1,0 0,1.5 1,0 0,-3 1,0 z m 4,2 -2,2 0,0.5 0.5,0 0,3 1,0 0,-1.5 1,0 0,1.5 1,0 0,-3 1,0 z"
          style="opacity:0.3;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect5991-0-4-1"
          width="12"
          height="12.000009"

--- a/src/village-18.svg
+++ b/src/village-18.svg
@@ -114,7 +114,7 @@
          height="18.000013"
          width="18"
          id="rect5989-6-0-6"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          inkscape:connector-curvature="0"
          id="path9415"

--- a/src/village-24.svg
+++ b/src/village-24.svg
@@ -117,7 +117,7 @@
          d="m 638,1319.3622 -4.5,4 c -0.5,0.5 0,1 0.5,1 l 1,0 0,5 1,0 1,0 0,-3 2,0 0,3 1,0 1,0 0,-5 1,0 c 0.5,0 1,-0.5 0.5,-1 l -4.5,-4 z m 9,3 -4.5,4 c -0.5,0.5 0,1 0.5,1 l 1,0 0,5 1,0 1,0 0,-3 2,0 0,3 1,0 1,0 0,-5 1,0 c 0.5,0 1,-0.5 0.5,-1 l -4.5,-4 z"
          id="path9528" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect7325-2-7-0-6"
          width="24"
          height="24.000017"

--- a/src/warehouse-18.svg
+++ b/src/warehouse-18.svg
@@ -106,7 +106,7 @@
        inkscape:export-xdpi="89.996864"
        inkscape:export-ydpi="89.996864">
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect13488-3"
          width="18.000017"
          height="18.000031"

--- a/src/warehouse-24.svg
+++ b/src/warehouse-24.svg
@@ -121,7 +121,7 @@
          d="m 761,3 -7.5,6.5 c -0.36201,0.3017 -0.5,0.5 -0.5,0.75 0,0.4959 0.5,0.75 1,0.75 l 1,0 0,8 c 0,0.554 0.446,1 1,1 l 13,0 c 0.554,0 1,-0.446 1,-1 l 0,-8 1,0 c 0.5,0 1,-0.2541 1,-0.75 C 772,10 771.86201,9.8017 771.5,9.5 L 764,3 z m -2,9 7,0 0,0.5 -7,0 z m 0,2 7,0 0,0.5 -7,0 z m 0,2 7,0 0,0.5 -7,0 z m 0,2 7,0 0,0.5 -7,0 z"
          style="opacity:0.3;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect13515-8"
          width="24.000017"
          height="24.000034"

--- a/src/waste-basket-12.svg
+++ b/src/waste-basket-12.svg
@@ -118,7 +118,7 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccccccccccccccccc" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22536-5"
          width="11.999998"
          height="12.000007"

--- a/src/waste-basket-18.svg
+++ b/src/waste-basket-18.svg
@@ -117,7 +117,7 @@
          d="m 349.518,1268.3622 c -0.20411,0 -0.268,0.1643 -0.268,0.3684 l 0,1.6316 -2.51315,0 c -0.40822,0 -0.73685,0.092 -0.73685,0.5 0,0.4083 0.32863,0.5 0.73685,0.5 l 9.52631,0 c 0.40821,0 0.73684,-0.092 0.73684,-0.5 0,-0.4082 -0.32863,-0.5 -0.73684,-0.5 l -2.51316,0 0,-1.6316 c 0,-0.2041 -0.16389,-0.3684 -0.368,-0.3684 z m 0.482,0.7368 3,0 0,1.2632 -3,0 z m -3.26315,3.2632 c -0.40822,0 -0.78834,0.3343 -0.72122,0.7369 l 1.40542,8.5263 c 0.0664,0.4027 0.32863,0.7368 0.73685,0.7368 l 6.63157,0 c 0.40822,0 0.66972,-0.3342 0.73685,-0.7368 l 1.45805,-8.5263 c 0.0688,-0.4023 -0.313,-0.7369 -0.72121,-0.7369 z"
          id="path5652" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect5693"
          width="18.000017"
          height="18.000031"

--- a/src/waste-basket-24.svg
+++ b/src/waste-basket-24.svg
@@ -123,7 +123,7 @@
          height="24.000017"
          width="24"
          id="rect5691"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/water-12.svg
+++ b/src/water-12.svg
@@ -107,7 +107,7 @@
          height="12.000007"
          width="11.999998"
          id="rect22613-5"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          sodipodi:nodetypes="sscss"
          inkscape:connector-curvature="0"

--- a/src/water-18.svg
+++ b/src/water-18.svg
@@ -111,7 +111,7 @@
          d="m 273.5,1305.3622 c -2.33186,0 -4.5,-2 -4.5,-4.5 0,-2.5278 3.41667,-7.0556 4.5,-8.5 1.08334,1.4444 4.5,5.9722 4.5,8.5 0,2.5 -2.16813,4.5 -4.5,4.5 z"
          style="opacity:0.3;color:#000000;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22611-2"
          width="18.000017"
          height="18.000031"

--- a/src/water-24.svg
+++ b/src/water-24.svg
@@ -117,7 +117,7 @@
          height="24.000017"
          width="24"
          id="rect22609-8"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
          style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          d="m 259,1304.8622 c 0,-3.5 -5,-9.5 -6.5,-11.5 -1.5,2 -6.5,8 -6.5,11.5 0,3.5 3.27126,6.5 6.5,6.5 3.22874,0 6.5,-3 6.5,-6.5 z"

--- a/src/wetland-12.svg
+++ b/src/wetland-12.svg
@@ -108,7 +108,7 @@
          transform="translate(-120,1050.3622)"
          id="path4812" />
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22613-5-9"
          width="11.999998"
          height="12.000007"

--- a/src/wetland-18.svg
+++ b/src/wetland-18.svg
@@ -120,7 +120,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22611-2-1"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/wetland-24.svg
+++ b/src/wetland-24.svg
@@ -106,7 +106,7 @@
        inkscape:export-xdpi="89.996864"
        inkscape:export-ydpi="89.996864">
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22609-8-4"
          width="24"
          height="24.000017"

--- a/src/zoo-12.svg
+++ b/src/zoo-12.svg
@@ -117,7 +117,7 @@
            style="color:#000000;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22258"
          width="11.999998"
          height="12.000007"

--- a/src/zoo-18.svg
+++ b/src/zoo-18.svg
@@ -125,7 +125,7 @@
          height="18.000031"
          width="18.000017"
          id="rect22256"
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/zoo-24.svg
+++ b/src/zoo-24.svg
@@ -133,7 +133,7 @@
         </g>
       </g>
       <rect
-         style="opacity:0.5;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="opacity:0;color:#000000;fill:none;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          id="rect22254"
          width="24"
          height="24.000017"


### PR DESCRIPTION
Background: Each icon contains an invisible `<rect>` object for
applications like Mapnik that try to set the canvas size based on the
objects within the SVG. If Mapnik's marker-fill feature is used, the
fill:none is overridden and these shapes become visible. Setting the
opacity to 0 should prevent this.

This change only affects the source SVGs; PNG and SDF renders are unchanged.

cc @springmeyer @samanpwbb  
