### PR TITLE
Provide explicit values to templates

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ options: full
       <li class='maki-icon <%- icon%>'><%- name %> icon</li>
       <li class='title-box'>
         <span class='maki-icon full <%- icon%>'></span>
-        <%- title%>
+        <%- name%>
         <small><%- icon %></small>
       </li>
     </ul>

--- a/www/site.js
+++ b/www/site.js
@@ -32,7 +32,7 @@ maki.search = function () {
     var search = $('#search');
     var searchResults = _.template($('#search-icons').html());
     var count = _.template($('#count').html());
-    var set = {}, total = 0;
+    var total = 0;
 
     function howMany() {
       $('.count').append(count({
@@ -62,10 +62,11 @@ maki.search = function () {
           return i.tags[0] === 'deprecated';
       })
       .map(function(icon){
-        set.title = icon.name;
-        set.icon = icon.icon;
         total++;
-        $('#maki-set').append(template(set));
+        $('#maki-set').append(template({
+          name: icon.name || '',
+          title: icon.title || ''
+        }));
         return icon;
       })
       .value();
@@ -94,7 +95,10 @@ maki.search = function () {
             matches.forEach(function(p) {
                 $('#search-results ul#results')
                   .addClass('active clearfix pad3 size-' + widthClass)
-                  .append(searchResults(p));
+                  .append(searchResults({
+                    icon: p.icon || '',
+                    name: p.name || ''
+                  }));
             });
             if (matches.length) return;
         }


### PR DESCRIPTION
Both 'name' and 'title' were being used by the icon-collection template,
but only title was passed in. This caused name to either be undefined or
fall back to the global name.

Now all properties are explicitly passed to templates. 'name' and 'title'
are normalized as 'name'.