### PR TITLE
Update townhall 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v7.0.0
 
+- update townhall icon
 - removes all `-11.svg` sizes
 - removes `-15.svg` from maki names
 - `px` in svg width/height attributes are removed

--- a/icons/town-hall.svg
+++ b/icons/town-hall.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg version="1.1" id="town-hall" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 15 15">
-  <path id="path7509" d="M7.5,0L1,3.4453V4h13V3.4453L7.5,0z M2,5v5l-1,1.5547V13h13v-1.4453L13,10V5H2z M4,6h1v5.5H4V6z M7,6h1v5.5H7&#xA;&#x9;V6z M10,6h1v5.5h-1V6z"/>
+<svg version="1.1" id="town-hall-15" xmlns="http://www.w3.org/2000/svg" width="15px" height="15px" viewBox="0 0 15 15">
+  <path d="M13,3.9902H9.0114l-0.0114-0.5V0.999L7.5045-0.0079L6.0034,0.999v2.9913H2L1,4.9426V6h13V4.9426L13,3.9902z M7.4904,1.4921&#xA;&#x9;c0.4118,0,0.7456,0.3358,0.7456,0.75c0,0.4142-0.3338,0.75-0.7456,0.75s-0.7455-0.3358-0.7455-0.75&#xA;&#x9;C6.7448,1.8279,7.0786,1.4921,7.4904,1.4921z M13,7H2v4l-1,1.5547V14h13v-1.4453L13,11V7z M5,12.5H4V8h1V12.5z M8,12.5H7V8h1V12.5z&#xA;&#x9; M11,12.5h-1V8h1V12.5z"/>
 </svg>


### PR DESCRIPTION
Per [discussions](https://github.com/mapbox/maki/issues/505#issuecomment-789031511) on the update museum icon ticket, I have updated the townhall, so that townhall is visually different compared to our museum icon. 

I used the existing townhall icon as a guide for shape and pixel widths

<img width="20" alt="Screen Shot 2021-03-02 at 3 49 48 PM" src="https://user-images.githubusercontent.com/7087091/109713232-f3b0c780-7b6e-11eb-8a18-91aef8bbfb3f.png">

## Description of change

<!-- Briefly describe your changes here. If you are replacing an existing icon, provide a before and after screenshot -->
Per [discussions](https://github.com/mapbox/maki/issues/505#issuecomment-789031511) on the update museum icon ticket, I have updated the townhall, so that townhall is visually different compared to our museum icon. 

I used the existing townhall icon as a guide for shape and pixel widths

### Link to demonstration

<!-- Provide a link to a interactive map that uses the new icon with 11x11 and 15x15 variation. -->
<!-- NOTE: upload your icon to the Maki icon editor (linked below) and add a 1px stroke colored #ffffff before uploading to an interactive map. -->

Test style [here](https://api.mapbox.com/styles/v1/vkwetzel/ckmgatops1wvk17lbziuy5ui1.html?fresh=true&title=view&access_token=pk.eyJ1Ijoidmt3ZXR6ZWwiLCJhIjoiY2swNzNzamw3MDB6azNtcGVvN3cxNTJzZSJ9.YY56WOsc0ZNIK9YTwosnTw#18.84/42.9163058/-89.2170897)

Test [style #2](https://api.mapbox.com/styles/v1/vkwetzel/ckmgatops1wvk17lbziuy5ui1.html?fresh=true&title=view&access_token=pk.eyJ1Ijoidmt3ZXR6ZWwiLCJhIjoiY2swNzNzamw3MDB6azNtcGVvN3cxNTJzZSJ9.YY56WOsc0ZNIK9YTwosnTw#15.36/52.517075/13.408115)

---

This ticket work is in conjunction with the museum ticket update. 

See [discussions](https://github.com/mapbox/maki/issues/505#issuecomment-789031511) on the `update museum icon` ticket

### For author

- [x] Cite changes under the `HEAD` tag in [`CHANGELOG.md`](../CHANGELOG.md)
- [x] PR contains only one 15x15 icon
- [ ] Changes fall in accordance to the [Maki guidelines](https://labs.mapbox.com/maki-icons/guidelines/)
  - [ ] Icon geometry is aligned to the pixel grid
  - [ ] Icon stays within a 2px trim area
  - [ ] Icon uses common geometric building blocks used throughout Maki
  - [ ] Icon corners are rounded in either full or half pixel increments
  - [ ] Any strokes use 1px
- [ ] Upload the new icon to the [Maki icon editor](https://labs.mapbox.com/maki-icons/editor/)
  - [ ] Compare with existing icons
  - [ ] Test that stroke/backgrounds/padding work visually

### For reviewer

- [ ] Review the interactive map provided to confirm legibility and harmony with existing icons
- [ ] Review each icon variation in an editor, turn on grids and outlines and confirm pixel alignment is maintained to the nearest or half pixel
- [ ] Confirm file requirements stated in [Maki guidelines](https://labs.mapbox.com/maki-icons/guidelines/) are met 
- [ ] Confirm all other changes fall in accordance to the [Maki guidelines](https://labs.mapbox.com/maki-icons/guidelines/)



